### PR TITLE
Get rid of FontId; always look through all fonts

### DIFF
--- a/src/SpriteFontPlus.sln
+++ b/src/SpriteFontPlus.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28922.388
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteFontPlus", "SpriteFontPlus\SpriteFontPlus.csproj", "{ECCBE6F6-B153-4B31-B0A3-29022BFBE997}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ECCBE6F6-B153-4B31-B0A3-29022BFBE997}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECCBE6F6-B153-4B31-B0A3-29022BFBE997}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECCBE6F6-B153-4B31-B0A3-29022BFBE997}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECCBE6F6-B153-4B31-B0A3-29022BFBE997}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4481FEF2-E143-43D4-8AAF-F63C4B31D0BE}
+	EndGlobalSection
+EndGlobal

--- a/src/SpriteFontPlus/DynamicSpriteFont.cs
+++ b/src/SpriteFontPlus/DynamicSpriteFont.cs
@@ -57,18 +57,6 @@ namespace SpriteFontPlus
 			}
 		}
 
-		public int FontId
-		{
-			get
-			{
-				return _fontSystem.FontId;
-			}
-			set
-			{
-				_fontSystem.FontId = value;
-			}
-		}
-
 		public int DefaultFontId
 		{
 			get
@@ -148,6 +136,16 @@ namespace SpriteFontPlus
 
 			return new Rectangle((int)bounds.X, (int)bounds.Y, (int)(bounds.X2 - bounds.X), (int)(bounds.Y2 - bounds.Y));
 		}
+
+		public void GetLineBounds(float y, out float miny, out float maxy)
+		{
+            _fontSystem.LineBounds(y, out miny, out maxy);
+		}
+
+        public float GetLineHeight()
+        {
+            return _fontSystem.LineHeight();
+        }
 
 		public void ExpandAtlas(int newWidth, int newHeight)
 		{

--- a/src/SpriteFontPlus/SpriteFontPlus.csproj
+++ b/src/SpriteFontPlus/SpriteFontPlus.csproj
@@ -1,48 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(SolutionDir)SolutionDefines.targets" />
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Authors>SpriteFontPlusTeam</Authors>
-    <Product>SpriteFontPlus</Product>
-    <Description>Library extending functionality of the SpriteFont.</Description>
-    <PackageLicense>https://github.com/rds1983/SpriteFontPlus#license</PackageLicense>
-    <PackageProjectUrl>https://github.com/rds1983/SpriteFontPlus</PackageProjectUrl>
-    <NoWarn>NU1701</NoWarn>
-    <AssemblyName>SpriteFontPlus</AssemblyName>
-    <RootNamespace>SpriteFontPlus</RootNamespace>
-    <Version>1.0.0.0</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <PackageId>SpriteFontPlus.MonoGame</PackageId>
-    <OutputPath>bin\MonoGame\$(Configuration)</OutputPath>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-    <PackageId>SpriteFontPlus.FNA</PackageId>
-    <OutputPath>bin\FNA\$(Configuration)</OutputPath>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="$(DefineConstants.Contains('XENKO'))">
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>SpriteFontPlus.Xenko</PackageId>
-    <OutputPath>bin\Xenko\$(Configuration)</OutputPath>
-  </PropertyGroup>
-  
-  <ItemGroup Condition="$(DefineConstants.Contains('MONOGAME'))">
-    <PackageReference Include="MonoGame.Framework.Portable" PrivateAssets="All" Version="3.6.0.1625" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.DesktopGL.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(DefineConstants.Contains('FNA'))">
-    <ProjectReference Include="..\..\deps\FNA\FNA.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(DefineConstants.Contains('XENKO'))">
-    <PackageReference Include="Xenko.Engine" Version="3.1.0.1-beta01-0349" PrivateAssets="contentfiles;analyzers" />
-    <PackageReference Include="Xenko.Core" Version="3.1.0.1-beta01-0349" PrivateAssets="contentfiles;analyzers" />
-  </ItemGroup>  
 </Project>


### PR DESCRIPTION
This should replace the topmost commit in Quaver/SpriteFontPlus.

IIRC, the idea I had for various e.g. metrics which were originally computed from a single font, was to go through all fonts and return the minimal or maximal value as makes sense. This way, if a line starts off with characters from a single font, and then suddenly a character from another font is added, the metrics won't suddenly jump around.